### PR TITLE
Handle Small Distances Between Neighbors

### DIFF
--- a/hydragnn/models/DIMEStack.py
+++ b/hydragnn/models/DIMEStack.py
@@ -182,9 +182,15 @@ class DIMEStack(Base):
         pos_ki = (
             pos_kj + pos_ji
         )  # It's important to calculate the vectors separately and then add in case of periodic boundary conditions
-        a = (pos_ji * pos_ki).sum(dim=-1)
-        b = torch.cross(pos_ji, pos_ki).norm(dim=-1)
-        angle = torch.atan2(b, a)
+        
+        # Avoid instabilities when using positional gradients by masking the angles when a distance is too close to zero
+        eps = 1e-3
+        valid_mask = ~((pos_ji.norm(dim=-1) < eps) | (pos_kj.norm(dim=-1) < eps) | (pos_ki.norm(dim=-1) < eps))  # Check if any relative vectors are too small
+        angle = torch.zeros(pos_ji.size(0), device=pos_ji.device)
+        a = (pos_ji[valid_mask] * pos_ki[valid_mask]).sum(dim=-1)
+        b = torch.cross(pos_ji[valid_mask], pos_ki[valid_mask], dim=-1).norm(dim=-1)
+        valid_angle = torch.atan2(b, a)
+        angle[valid_mask] = valid_angle
 
         rbf = self.rbf(edge_dist.squeeze())
         sbf = self.sbf(edge_dist.squeeze(), angle, idx_kj)

--- a/hydragnn/utils/model/operations.py
+++ b/hydragnn/utils/model/operations.py
@@ -23,14 +23,14 @@ def get_edge_vectors_and_lengths(
     edge_index: torch.Tensor,  # [2, n_edges]
     shifts: torch.Tensor,  # [n_edges, 3]
     normalize: bool = False,
-    eps: float = 1e-9,
+    eps: float = 1e-3,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     sender = edge_index[0]
     receiver = edge_index[1]
     vectors = positions[receiver] - positions[sender] + shifts  # [n_edges, 3]
-    lengths = torch.linalg.norm(vectors, dim=-1, keepdim=True)  # [n_edges, 1]
+    lengths = torch.linalg.norm(vectors, dim=-1, keepdim=True) + eps  # [n_edges, 1]
     if normalize:
-        vectors_normed = vectors / (lengths + eps)
+        vectors_normed = vectors / lengths
         return vectors_normed, lengths
 
     return vectors, lengths


### PR DESCRIPTION
Handle small distances more gracefully. If the neural network uses `1/distance` relation, whether learned or through radial basis function, this can result in instability. Distances of zero must be explicitly prevented to prevent NaNs when using `compute_grad_energy`.